### PR TITLE
Add SASL Auth Config support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,6 @@ fabric.properties
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
 
+/twitter-stream.iml
+/target/
+/.idea/

--- a/README.md
+++ b/README.md
@@ -18,9 +18,21 @@ Oracle JDK 1.8 (64 bit )
 # How to Run
 Provide JVM Argument for TwitterKafkaProducer.java in following order
 
+```
 java TwitterKafkaProducer.java <consumer_key> <consumer_secret> <account_token> <account_secret> <hashtag/term>
-                               			                               			 
-You can configure name of the topic in [TwittterKafkaConfig.java](src/main/java/com/saurzcode/twitter/config/TwitterKafkaConfig.java)
+```
+
+The topic and bootstrap servers for Kafka can be configured with option arguments. 
+If using SASL Auth to Kafka, also set username and password. See below for usage. 
+
+```
+usage: twitter-stream
+ -password <arg>   SASL Auth password
+ -servers <arg>    Comma separated list of Kafka bootstrap servers
+ -topic <arg>      Kafka topic
+ -username <arg>   SASL Auth username
+```
+
 # Build Environment :
 Eclipse/Intellij
 Apache Maven 

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,12 @@
 			<artifactId>guava</artifactId>
 			<version>[24.1.1,)</version>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.3</version>
+        </dependency>
+    </dependencies>
 
 	<properties>
 		<java.version>1.8</java.version>

--- a/src/main/java/com/saurzcode/twitter/config/TwitterKafkaConfig.java
+++ b/src/main/java/com/saurzcode/twitter/config/TwitterKafkaConfig.java
@@ -1,7 +1,68 @@
 package com.saurzcode.twitter.config;
 
-public class TwitterKafkaConfig {
+import org.apache.commons.cli.*;
 
-    public static final String SERVERS = "localhost:9092";
-    public static final String TOPIC = "twitter-topic";
+public class TwitterKafkaConfig {
+    final static String TopicOption = "topic";
+    final static String ServersOption = "servers";
+    final static String UserNameOption = "username";
+    final static String PasswordOption = "password";
+
+    public static String CONSUMER_KEY = "";
+    public static String CONSUMER_SECRET = "";
+    public static String TOKEN = "";
+    public static String SECRET = "";
+    public static String TERM = "";
+
+    public static String SERVERS = "localhost:9092";
+    public static String TOPIC = "twitter-topic";
+
+    // For Kafka SASL Auth
+    public static String USER_NAME = "";
+    public static String PASSWORD = "";
+
+    public static void SetFromArgs(String[] args) throws ParseException, IllegalArgumentException {
+        Options options = new Options();
+        options
+                .addOption(new Option(TopicOption, true, "Kafka topic"))
+                .addOption(new Option(ServersOption, true, "Comma separated list of Kafka bootstrap servers"))
+                .addOption(new Option(UserNameOption, true, "SASL Auth username"))
+                .addOption(new Option(PasswordOption, true, "SASL Auth password"));
+        CommandLineParser parser = new DefaultParser();
+        HelpFormatter formatter = new HelpFormatter();
+        CommandLine cmd;
+
+        try {
+            cmd = parser.parse(options, args);
+            if (cmd.hasOption(ServersOption)) {
+                TwitterKafkaConfig.SERVERS = cmd.getOptionValue(ServersOption);
+            }
+
+            if (cmd.hasOption(TopicOption)) {
+                TwitterKafkaConfig.TOPIC = cmd.getOptionValue(TopicOption);
+            }
+
+            if (cmd.hasOption(UserNameOption)) {
+                TwitterKafkaConfig.USER_NAME = cmd.getOptionValue(UserNameOption);
+            }
+
+            if (cmd.hasOption(PasswordOption)) {
+                TwitterKafkaConfig.PASSWORD = cmd.getOptionValue(PasswordOption);
+            }
+
+            String[] remaining = cmd.getArgs();
+            if (remaining.length != 5)
+                throw new IllegalArgumentException("Please Pass 5 arguments, in order - consumerKey, consumerSecret, token, secret, and term");
+            //These should be passed in VM arguments for the application.
+            TwitterKafkaConfig.CONSUMER_KEY = remaining[0];
+            TwitterKafkaConfig.CONSUMER_SECRET = remaining[1];
+            TwitterKafkaConfig.TOKEN = remaining[2];
+            TwitterKafkaConfig.SECRET = remaining[3];
+            TwitterKafkaConfig.TERM = remaining[4]; // term on twitter on which you want to filter the results on.
+        } catch (ParseException e) {
+            formatter.printHelp("twitter-stream", options);
+
+            throw e;
+        }
+    }
 }


### PR DESCRIPTION
To use the twitter-stream app with [cloudkarafka](https://www.cloudkarafka.com/), I added [SASL](https://docs.confluent.io/platform/current/kafka/authentication_sasl/index.html) support; others might find it useful too. 

The changes are backward compatible, and the args will still work. Options will allow setting the topic, bootstrap servers, and SASL Auth configuration explicitly. See Readme updates for usage. 
For easy debugging, we now print effective config values used by TwitterKafkaProducer. 

Verified changes both with local Kafka and remote cloudkarafka, which uses SASL.